### PR TITLE
[PM-3028] Update twisted version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ setup:  ## Setups environment
 
 .PHONY: buildout
 buildout:  ## Runs setup and buildout
+	rm -f .installed.cfg .mr.developer.cfg
 	if ! test -f bin/buildout;then make setup;fi
 	if ! test -f var/filestorage/Data.fs;then make standard-config; else bin/buildout -v;fi
 	git checkout .gitignore

--- a/base.cfg
+++ b/base.cfg
@@ -22,7 +22,6 @@ versions=versions
 # Add additional egg download sources here. dist.plone.org contains archives
 # of Plone packages.
 find-links =
-    http://twistedmatrix.com/Releases/Twisted/8.2/Twisted-8.2.0.tar.bz2
 
 # Add additional eggs here
 # elementtree is required by Plone

--- a/versions-base.cfg
+++ b/versions-base.cfg
@@ -172,7 +172,7 @@ imio.pm.wsclient = 1.16
 # Required by:
 # instance-async
 plone.app.async = 1.6
-Twisted = 8.2.0
+Twisted = 10.2.0
 uuid = 1.30
 zc.async = 1.5.4
 zc.dict = 1.2.1


### PR DESCRIPTION
https://support.imio.be/browse/PM-3028

- upgrade twisted 8.2.0->10.2.0
- supprime twistedmatrix find-link (la ressource n'existe plus)
- supprime .installed.cfg et .mr.developer.cfg dans le make buildout sur conseil d'olivier pour éviter des problèmes en voulant avoir un buildout propre.